### PR TITLE
[CI]: 👷 自动解析 TeX Live 依赖

### DIFF
--- a/.github/scripts/build_latex.py
+++ b/.github/scripts/build_latex.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Build the thesis and install missing TeX Live packages on demand.
+
+The package resolver prepares the primary TeX Live package list before the
+setup action runs. This script is the safety net for dependencies that are
+only visible while TeX expands package files, for example a package that
+loads another package without declaring it in texlive.tlpdb.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+COMMAND_PACKAGES = {
+    "biber": "biber",
+    "xelatex": "xetex",
+}
+
+MISSING_FILE_PATTERNS = [
+    re.compile(r"File [`'\"]([^`'\"]+)[`'\"] not found"),
+    re.compile(r"! I can't find file [`'\"]?([^`'\"\s]+)"),
+]
+
+
+def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    print(f"+ {' '.join(command)}", flush=True)
+    result = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.stdout:
+        print(result.stdout, end="")
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, command, result.stdout)
+    return result
+
+
+def tlmgr(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    if shutil.which("tlmgr") is None:
+        raise RuntimeError("tlmgr is not available; install TeX Live before running this script")
+    return run(["tlmgr", *args], check=check)
+
+
+def normalize_arch_package(package: str) -> str:
+    platform = tlmgr("print-platform").stdout.strip()
+    suffix = f".{platform}"
+    if package.endswith(suffix):
+        return package[: -len(suffix)]
+    return package
+
+
+def configure_tlmgr() -> None:
+    tlmgr("option", "docfiles", "0")
+    tlmgr("option", "srcfiles", "0")
+
+
+def parse_package_from_search_output(output: str, file_name: str) -> str | None:
+    current_package: str | None = None
+    candidates: list[tuple[int, str]] = []
+
+    for line in output.splitlines():
+        package_match = re.match(r"^([A-Za-z0-9_.+-]+):$", line)
+        if package_match:
+            current_package = package_match.group(1)
+            continue
+        if current_package is None:
+            continue
+        path = line.strip()
+        if not path or file_name not in path:
+            continue
+
+        if "/doc/" in path or "/source/" in path or path.startswith("doc/"):
+            score = 20
+        elif "/tex/" in path or path.startswith("texmf-dist/tex/"):
+            score = 0
+        elif path.startswith("bin/"):
+            score = 1
+        else:
+            score = 5
+        candidates.append((score, current_package))
+
+    if not candidates:
+        return None
+
+    candidates.sort()
+    return normalize_arch_package(candidates[0][1])
+
+
+def package_for_file(file_name: str) -> str:
+    escaped_file = re.escape(file_name)
+    result = tlmgr("search", "--global", "--file", f"/{escaped_file}$", check=False)
+    package = parse_package_from_search_output(result.stdout, file_name)
+    if package is None:
+        raise RuntimeError(f"Could not find a TeX Live package that provides {file_name}")
+    return package
+
+
+def install_packages(packages: set[str]) -> None:
+    if not packages:
+        return
+    tlmgr("install", *sorted(packages))
+
+
+def ensure_command(command: str) -> None:
+    if shutil.which(command) is not None:
+        return
+
+    package = COMMAND_PACKAGES.get(command)
+    if package is None:
+        package = package_for_file(command)
+
+    print(f"{command} is missing; installing TeX Live package {package}", flush=True)
+    install_packages({package})
+
+    if shutil.which(command) is None:
+        raise RuntimeError(f"{command} is still unavailable after installing {package}")
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def find_missing_files(output: str, log_file: Path) -> set[str]:
+    text = output + "\n" + read_text(log_file)
+    missing: set[str] = set()
+    for pattern in MISSING_FILE_PATTERNS:
+        missing.update(match.group(1) for match in pattern.finditer(text))
+    return {name for name in missing if not Path(name).exists()}
+
+
+def latex_command(main_file: Path, build_dir: Path) -> list[str]:
+    return [
+        "xelatex",
+        "-synctex=1",
+        "-interaction=nonstopmode",
+        "-file-line-error",
+        f"-output-directory={build_dir}",
+        str(main_file),
+    ]
+
+
+def build_once(main_file: Path, build_dir: Path) -> tuple[bool, set[str], int]:
+    build_dir.mkdir(parents=True, exist_ok=True)
+    (build_dir / "appendix").mkdir(exist_ok=True)
+    (build_dir / "chapters").mkdir(exist_ok=True)
+
+    stem = main_file.stem
+    log_file = build_dir / f"{stem}.log"
+    commands = [
+        latex_command(main_file, build_dir),
+        ["biber", f"--output-directory={build_dir}", stem],
+        latex_command(main_file, build_dir),
+        latex_command(main_file, build_dir),
+    ]
+
+    for command in commands:
+        result = run(command, check=False)
+        if result.returncode == 0:
+            continue
+
+        missing_files = find_missing_files(result.stdout, log_file)
+        if missing_files:
+            return False, missing_files, result.returncode
+        return False, set(), result.returncode
+
+    return True, set(), 0
+
+
+def build_with_autoinstall(main_file: Path, build_dir: Path, max_rounds: int) -> int:
+    configure_tlmgr()
+    ensure_command("xelatex")
+    ensure_command("biber")
+
+    installed_missing_files: set[str] = set()
+    for round_index in range(1, max_rounds + 1):
+        print(f"Build attempt {round_index}/{max_rounds}", flush=True)
+        success, missing_files, returncode = build_once(main_file, build_dir)
+        if success:
+            return 0
+
+        new_missing_files = missing_files - installed_missing_files
+        if not new_missing_files:
+            return returncode
+
+        package_by_file = {
+            file_name: package_for_file(file_name)
+            for file_name in sorted(new_missing_files)
+        }
+        print(
+            "Installing missing TeX Live packages: "
+            + ", ".join(
+                f"{file_name}->{package_name}"
+                for file_name, package_name in package_by_file.items()
+            ),
+            flush=True,
+        )
+        install_packages(set(package_by_file.values()))
+        installed_missing_files.update(new_missing_files)
+
+    print(f"Build did not converge after {max_rounds} attempts", file=sys.stderr)
+    return 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--main", default="SWJTU_Bachelor_Thesis.tex")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--max-rounds", type=int, default=12)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    main_file = Path(args.main)
+    build_dir = Path(args.build_dir)
+    return build_with_autoinstall(main_file, build_dir, args.max_rounds)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/resolve_texlive_packages.py
+++ b/.github/scripts/resolve_texlive_packages.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Generate the TeX Live package list required by this repository.
+
+The generated file is consumed by setup-texlive-action's package-file input,
+so the cache key follows source-level dependency changes without maintaining
+a hand-written package list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import lzma
+import platform
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+TLPDB_URL = "https://mirror.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz"
+BASE_PACKAGES = {
+    "biber",
+    "scheme-basic",
+    "xetex",
+}
+LOCAL_PACKAGE_PREFIXES = (
+    "style/",
+    "./",
+    "../",
+)
+TEXT_EXTENSIONS = {
+    ".cls",
+    ".ltx",
+    ".sty",
+    ".tex",
+}
+
+
+@dataclass
+class TexLivePackage:
+    name: str
+    depends: list[str] = field(default_factory=list)
+    files: list[str] = field(default_factory=list)
+
+
+def guess_texlive_platform() -> str:
+    machine = platform.machine().lower()
+    system = platform.system().lower()
+    if system == "linux" and machine in {"x86_64", "amd64"}:
+        return "x86_64-linux"
+    if system == "darwin":
+        return "universal-darwin"
+    raise RuntimeError(
+        "Cannot infer TeX Live platform; pass --platform explicitly "
+        "(for GitHub ubuntu-latest use x86_64-linux)"
+    )
+
+
+def read_tlpdb(path: Path | None) -> str:
+    if path is not None:
+        return lzma.decompress(path.read_bytes()).decode("utf-8", errors="replace")
+
+    with urllib.request.urlopen(TLPDB_URL, timeout=120) as response:
+        compressed = response.read()
+    return lzma.decompress(compressed).decode("utf-8", errors="replace")
+
+
+def parse_tlpdb(text: str) -> dict[str, TexLivePackage]:
+    packages: dict[str, TexLivePackage] = {}
+    current: TexLivePackage | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if line.startswith("name "):
+            current = TexLivePackage(line[5:].strip())
+            packages[current.name] = current
+            continue
+        if current is None:
+            continue
+        if line.startswith("depend "):
+            current.depends.append(line[7:].strip())
+            continue
+
+        file_path = line.strip()
+        if re.match(r"^(RELOC|texmf-dist|bin|runfiles|srcfiles|docfiles)/", file_path):
+            current.files.append(file_path.replace("RELOC/", "texmf-dist/"))
+
+    return packages
+
+
+def package_for_file(
+    packages: dict[str, TexLivePackage],
+    file_name: str,
+    texlive_platform: str,
+) -> str:
+    candidates: list[tuple[int, str]] = []
+    file_suffix = f"/{file_name}"
+
+    for package in packages.values():
+        for file_path in package.files:
+            if not file_path.endswith(file_suffix):
+                continue
+
+            if file_path.startswith(f"bin/{texlive_platform}/"):
+                score = 0
+            elif file_path.startswith("texmf-dist/tex/"):
+                score = 1
+            elif file_path.startswith("bin/"):
+                score = 8
+            elif "/doc/" in file_path or "/source/" in file_path:
+                score = 20
+            else:
+                score = 10
+            candidates.append((score, package.name))
+
+    if not candidates:
+        raise RuntimeError(f"Could not find a TeX Live package providing {file_name}")
+
+    candidates.sort()
+    return candidates[0][1]
+
+
+def split_tex_names(names: str) -> list[str]:
+    return [name.strip() for name in names.split(",") if name.strip()]
+
+
+def package_file_exists(root: Path, name: str, extension: str) -> bool:
+    return (root / f"{name}{extension}").exists()
+
+
+def package_is_local(root: Path, name: str, extension: str) -> bool:
+    if name.startswith(LOCAL_PACKAGE_PREFIXES):
+        return package_file_exists(root, name, extension)
+    return package_file_exists(root, name, extension)
+
+
+def collect_tex_files(root: Path) -> list[Path]:
+    return [
+        path
+        for path in root.rglob("*")
+        if path.is_file()
+        and path.suffix in TEXT_EXTENSIONS
+        and ".git" not in path.parts
+        and "build" not in path.parts
+    ]
+
+
+def strip_tex_comments(text: str) -> str:
+    stripped_lines: list[str] = []
+    for line in text.splitlines():
+        for index, character in enumerate(line):
+            if character != "%":
+                continue
+            backslashes = 0
+            cursor = index - 1
+            while cursor >= 0 and line[cursor] == "\\":
+                backslashes += 1
+                cursor -= 1
+            if backslashes % 2 == 0:
+                line = line[:index]
+                break
+        stripped_lines.append(line)
+    return "\n".join(stripped_lines)
+
+
+def collect_required_files(root: Path) -> set[str]:
+    required = {
+        "biber",
+        "xelatex",
+    }
+
+    command_pattern = re.compile(
+        r"\\(?P<command>documentclass|RequirePackage|usepackage)"
+        r"(?:\[(?P<options>[^\]]*)\])?"
+        r"\{(?P<names>[^}]+)\}",
+        re.MULTILINE,
+    )
+    biblatex_style_pattern = re.compile(r"style\s*=\s*([A-Za-z0-9_-]+)")
+
+    for tex_file in collect_tex_files(root):
+        text = strip_tex_comments(tex_file.read_text(encoding="utf-8", errors="replace"))
+        for match in command_pattern.finditer(text):
+            command = match.group("command")
+            options = match.group("options") or ""
+            names = split_tex_names(match.group("names"))
+            if command == "documentclass":
+                for name in names:
+                    if not package_is_local(root, name, ".cls"):
+                        required.add(f"{name}.cls")
+            else:
+                for name in names:
+                    if not package_is_local(root, name, ".sty"):
+                        required.add(f"{name}.sty")
+                    if name == "biblatex":
+                        for style_match in biblatex_style_pattern.finditer(options):
+                            style = style_match.group(1)
+                            required.add(f"{style}.bbx")
+                            required.add(f"{style}.cbx")
+
+    return required
+
+
+def normalize_dependency(dependency: str, texlive_platform: str) -> str | None:
+    if dependency.startswith("setting_available_architectures:"):
+        return None
+    if dependency.endswith(".ARCH"):
+        return dependency[: -len(".ARCH")] + f".{texlive_platform}"
+    return dependency
+
+
+def dependency_closure(
+    packages: dict[str, TexLivePackage],
+    roots: set[str],
+    texlive_platform: str,
+) -> set[str]:
+    resolved: set[str] = set()
+    stack = list(roots)
+
+    while stack:
+        package_name = stack.pop()
+        if package_name in resolved:
+            continue
+        if package_name not in packages:
+            raise RuntimeError(f"Package {package_name} is not present in texlive.tlpdb")
+
+        resolved.add(package_name)
+        for dependency in packages[package_name].depends:
+            normalized = normalize_dependency(dependency, texlive_platform)
+            if normalized and normalized not in resolved:
+                stack.append(normalized)
+
+    return resolved
+
+
+def write_package_file(path: Path, packages: set[str], required_files: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Generated by .github/scripts/resolve_texlive_packages.py",
+        "# Do not edit by hand; update TeX sources or the resolver instead.",
+        "# Runtime-only dependencies are handled by .github/scripts/build_latex.py.",
+        "",
+        *sorted(packages),
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+    print(f"Resolved {len(required_files)} TeX files/commands into {len(packages)} packages")
+    print(f"Wrote {path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--platform", default=None)
+    parser.add_argument("--tlpdb", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+    texlive_platform = args.platform or guess_texlive_platform()
+    packages = parse_tlpdb(read_tlpdb(args.tlpdb))
+    required_files = collect_required_files(root)
+
+    root_packages = set(BASE_PACKAGES)
+    for file_name in required_files:
+        if file_name in {"biber", "xelatex"}:
+            continue
+        root_packages.add(package_for_file(packages, file_name, texlive_platform))
+
+    resolved_packages = dependency_closure(packages, root_packages, texlive_platform)
+    write_package_file(args.output, resolved_packages, required_files)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/resolve_texlive_packages.py
+++ b/.github/scripts/resolve_texlive_packages.py
@@ -18,7 +18,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
-TLPDB_URL = "https://mirror.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz"
+DEFAULT_TLPDB_URLS = [
+    "https://mirrors.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz",
+    "https://mirror.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz",
+    "https://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz",
+    "https://mirror.math.princeton.edu/pub/CTAN/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz",
+]
 BASE_PACKAGES = {
     "biber",
     "scheme-basic",
@@ -57,13 +62,25 @@ def guess_texlive_platform() -> str:
     )
 
 
-def read_tlpdb(path: Path | None) -> str:
+def read_tlpdb(path: Path | None, urls: list[str]) -> str:
     if path is not None:
         return lzma.decompress(path.read_bytes()).decode("utf-8", errors="replace")
 
-    with urllib.request.urlopen(TLPDB_URL, timeout=120) as response:
-        compressed = response.read()
-    return lzma.decompress(compressed).decode("utf-8", errors="replace")
+    errors: list[str] = []
+    for url in urls:
+        try:
+            print(f"Downloading TeX Live package database from {url}")
+            with urllib.request.urlopen(url, timeout=45) as response:
+                compressed = response.read()
+            return lzma.decompress(compressed).decode("utf-8", errors="replace")
+        except Exception as error:
+            errors.append(f"{url}: {error}")
+            print(f"Failed to download {url}: {error}", file=sys.stderr)
+
+    raise RuntimeError(
+        "Could not download texlive.tlpdb.xz from any configured URL:\n"
+        + "\n".join(errors)
+    )
 
 
 def parse_tlpdb(text: str) -> dict[str, TexLivePackage]:
@@ -255,6 +272,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--platform", default=None)
     parser.add_argument("--tlpdb", type=Path, default=None)
+    parser.add_argument(
+        "--tlpdb-url",
+        action="append",
+        default=[],
+        help="URL for texlive.tlpdb.xz; may be passed multiple times",
+    )
     return parser.parse_args()
 
 
@@ -262,7 +285,8 @@ def main() -> int:
     args = parse_args()
     root = args.root.resolve()
     texlive_platform = args.platform or guess_texlive_platform()
-    packages = parse_tlpdb(read_tlpdb(args.tlpdb))
+    urls = args.tlpdb_url or DEFAULT_TLPDB_URLS
+    packages = parse_tlpdb(read_tlpdb(args.tlpdb, urls))
     required_files = collect_required_files(root)
 
     root_packages = set(BASE_PACKAGES)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'master'
     paths:
+      - '.github/scripts/**'
+      - '.github/workflows/ci.yml'
       - 'appendix/**'
       - 'bibliography/**'
       - 'chapters/**'
@@ -20,19 +22,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Resolve TeX Live packages
+        run: python3 .github/scripts/resolve_texlive_packages.py --platform x86_64-linux --output .github/texlive-packages.generated
+
       - name: Set up TeX Live
         uses: TeX-Live/setup-texlive-action@v3
         with:
-          packages: >
-            scheme-full
+          package-file: .github/texlive-packages.generated
 
       - name: Compile LaTeX (xelatex -> biber -> xelatex*2)
-        run: |
-          mkdir -p build/appendix build/chapters
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
-          biber --output-directory=build SWJTU_Bachelor_Thesis
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
+        run: python3 .github/scripts/build_latex.py
 
       - name: Upload source files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -8,6 +8,8 @@ on:
     tags:
       - 'v*.*.*'
     paths:
+      - '.github/scripts/**'
+      - '.github/workflows/deploy-pages.yml'
       - 'appendix/**'
       - 'bibliography/**'
       - 'chapters/**'
@@ -27,19 +29,16 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Resolve TeX Live packages
+        run: python3 .github/scripts/resolve_texlive_packages.py --platform x86_64-linux --output .github/texlive-packages.generated
+
       - name: Set up TeX Live
         uses: TeX-Live/setup-texlive-action@v3
         with:
-          packages: >
-            scheme-full
+          package-file: .github/texlive-packages.generated
 
       - name: Build PDF
-        run: |
-          mkdir -p build/appendix build/chapters
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
-          biber --output-directory=build SWJTU_Bachelor_Thesis
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
+        run: python3 .github/scripts/build_latex.py
 
       - name: Prepare site directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,16 @@ jobs:
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Resolve TeX Live packages
+        run: python3 .github/scripts/resolve_texlive_packages.py --platform x86_64-linux --output .github/texlive-packages.generated
+
       - name: Set up TeX Live
         uses: TeX-Live/setup-texlive-action@v3
         with:
-          packages: >
-            scheme-full
+          package-file: .github/texlive-packages.generated
 
       - name: Compile LaTeX (xelatex -> biber -> xelatex*2)
-        run: |
-          mkdir -p build/appendix build/chapters
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
-          biber --output-directory=build SWJTU_Bachelor_Thesis
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
-          xelatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=build SWJTU_Bachelor_Thesis.tex
+        run: python3 .github/scripts/build_latex.py
 
       - name: Zip source files
         run: |


### PR DESCRIPTION
## 变更
- 自动从 LaTeX 源码解析 TeX Live 依赖包，并将生成清单交给 setup-texlive-action 安装与缓存
- 编译阶段保留缺失包自动补齐兜底，处理 texlive.tlpdb 未声明的运行时依赖
- 为 TeX Live 数据库下载增加多个 CTAN/global/US 镜像兜底

## 验证
- 本地 python3 -m py_compile .github/scripts/build_latex.py .github/scripts/resolve_texlive_packages.py
- 本地 python3 .github/scripts/resolve_texlive_packages.py --platform x86_64-linux --tlpdb /tmp/swjtu-texlive-tlpdb/texlive.tlpdb.xz --output /tmp/swjtu-texlive-packages-linux
- 本地 python3 .github/scripts/build_latex.py，生成 18 页 PDF
- GitHub Actions: https://github.com/abwuge/SWJTU_Bachelor_Thesis/actions/runs/27197016229

Closes #14